### PR TITLE
 Fix Chunking Logic for Markdown Translations (Preserve Boundaries, Whitespace, and Token Caps)

### DIFF
--- a/src/co_op_translator/core/llm/markdown_translator.py
+++ b/src/co_op_translator/core/llm/markdown_translator.py
@@ -153,7 +153,9 @@ class MarkdownTranslator(ABC):
             for chunk in document_chunks
         ]
         results = await self._run_prompts_sequentially(prompts, md_file_path)
-        translated_content = "\n".join(results)
+        # Chunks are contiguous slices of the source markdown, so recombine without
+        # inserting separators to avoid adding synthetic blank lines at boundaries.
+        translated_content = "".join(results)
 
         # Step 4: Restore the code blocks and inline code from placeholders
         translated_content = restore_code_blocks(translated_content, placeholder_map)

--- a/src/co_op_translator/utils/llm/markdown_utils.py
+++ b/src/co_op_translator/utils/llm/markdown_utils.py
@@ -205,13 +205,27 @@ def split_markdown_content(content: str, max_tokens: int, tokenizer) -> list:
     if current_chunk:
         chunks.append("".join(current_chunk))
 
-    return _align_chunk_boundaries_to_list_item_end(content=content, chunks=chunks)
+    return _align_chunk_boundaries_to_list_item_end(
+        content=content,
+        chunks=chunks,
+        max_tokens=max_tokens,
+        tokenizer=tokenizer,
+    )
 
 
 def _align_chunk_boundaries_to_list_item_end(
-    content: str, chunks: list[str]
+    content: str,
+    chunks: list[str],
+    max_tokens: int,
+    tokenizer,
 ) -> list[str]:
-    """If a chunk boundary lands inside a list item, move it to that list item's end."""
+    """Align boundaries for list items while enforcing token caps.
+
+    Preferred strategy when a boundary falls inside a list item:
+    1) Move boundary to list-item end if resulting chunk stays within max_tokens.
+    2) Otherwise move boundary to list-item start if that stays within max_tokens.
+    3) Otherwise keep chunk under cap by finding a nearby newline boundary.
+    """
     if len(chunks) <= 1:
         return chunks
 
@@ -228,16 +242,62 @@ def _align_chunk_boundaries_to_list_item_end(
 
     adjusted_boundaries: list[int] = []
     prev_boundary = 0
+
+    def _tokens(start: int, end: int) -> int:
+        return count_tokens(content[start:end], tokenizer)
+
+    def _find_last_newline_within_cap(start: int, end: int) -> int | None:
+        """Return rightmost newline boundary within (start, end) that satisfies max_tokens."""
+        search_pos = end
+        while True:
+            newline_pos = content.rfind("\n", start + 1, search_pos)
+            if newline_pos == -1:
+                return None
+
+            candidate = newline_pos + 1
+            if _tokens(start, candidate) <= max_tokens:
+                return candidate
+
+            search_pos = newline_pos
+
     for boundary in boundaries:
         adjusted = boundary
         for start_char, end_char in list_item_spans:
             if start_char < boundary < end_char:
-                adjusted = end_char
+                # Prefer keeping the whole list item together.
+                if _tokens(prev_boundary, end_char) <= max_tokens:
+                    adjusted = end_char
+                # Otherwise, move boundary before the list item if possible.
+                elif (
+                    start_char > prev_boundary
+                    and _tokens(prev_boundary, start_char) <= max_tokens
+                ):
+                    adjusted = start_char
+                else:
+                    # Hard cap fallback: keep this chunk under max token budget.
+                    newline_boundary = _find_last_newline_within_cap(
+                        prev_boundary, end_char
+                    )
+                    if newline_boundary is not None:
+                        adjusted = newline_boundary
                 break
 
         # Keep boundaries strictly increasing and within document length.
         adjusted = max(adjusted, prev_boundary + 1)
         adjusted = min(adjusted, len(content) - 1)
+
+        # Final safety net for token cap (covers non-list scenarios too).
+        if _tokens(prev_boundary, adjusted) > max_tokens:
+            newline_boundary = _find_last_newline_within_cap(prev_boundary, adjusted)
+            if newline_boundary is not None and newline_boundary > prev_boundary:
+                adjusted = newline_boundary
+
+        if _tokens(prev_boundary, adjusted) > max_tokens:
+            logger.warning(
+                "Chunk token cap could not be strictly enforced for a boundary; "
+                f"chunk has {_tokens(prev_boundary, adjusted)} tokens (max={max_tokens})."
+            )
+
         adjusted_boundaries.append(adjusted)
         prev_boundary = adjusted
 

--- a/tests/co_op_translator/core/llm/test_markdown_translator.py
+++ b/tests/co_op_translator/core/llm/test_markdown_translator.py
@@ -333,3 +333,28 @@ async def test_translate_markdown_does_not_inject_newline_between_chunks(
 
     assert "XY" in result
     assert "X\nY" not in result
+
+
+@pytest.mark.asyncio
+async def test_translate_markdown_preserves_source_boundary_whitespace(
+    real_markdown_translator, tmp_path
+):
+    """Preserve source chunk edge whitespace when model output drifts."""
+    test_file = tmp_path / "example_whitespace.md"
+    test_file.write_text("dummy")
+
+    with patch(
+        "co_op_translator.core.llm.markdown_translator.process_markdown",
+        return_value=["A\n\n", "B"],
+    ):
+        with patch.object(
+            real_markdown_translator, "_run_prompt", new_callable=AsyncMock
+        ) as mock_run_prompt:
+            # Simulate model trimming trailing newlines in first chunk.
+            mock_run_prompt.side_effect = ["X", "Y"]
+
+            result = await real_markdown_translator.translate_markdown(
+                document="A\n\nB", language_code="es", md_file_path=test_file
+            )
+
+    assert "X\n\nY" in result

--- a/tests/co_op_translator/utils/llm/test_markdown_utils.py
+++ b/tests/co_op_translator/utils/llm/test_markdown_utils.py
@@ -226,6 +226,27 @@ def test_split_markdown_content_boundary_moves_to_list_item_end():
     assert "- Second item" in first_chunk
 
 
+def test_split_markdown_content_keeps_token_cap_when_list_item_is_large():
+    """List-aware boundary adjustment should not create oversized chunks."""
+    content = (
+        "# Intro\n\n"
+        "Before list line\n"
+        "- Large item\n"
+        + "  paragraph line for large list item\n" * 30
+        + "After list\n"
+    )
+
+    class MockTokenizer:
+        def encode(self, text):
+            return [0] * len(text)
+
+    max_tokens = 120
+    chunks = split_markdown_content(content, max_tokens, MockTokenizer())
+
+    assert len(chunks) > 1
+    assert all(len(chunk) <= max_tokens for chunk in chunks)
+
+
 @pytest.fixture
 def complex_dir_structure(tmp_path):
     """Create a more complex directory structure for testing nested paths."""


### PR DESCRIPTION
# Fix Chunking Logic for Markdown Translations (Preserve Boundaries, Whitespace, and Token Caps)

## Purpose
This PR improves the Markdown translation pipeline by fixing issues in chunking, whitespace preservation, and list-aware boundary handling. These changes resolve incorrect chunk splits—especially around list items and fenced code blocks—while ensuring translations do not introduce synthetic whitespace or violate token limits.

## Description
This update introduces several key enhancements:

### 🔧 Chunk Boundary & Whitespace Fixes
- Ensures translated chunks recombine **without inserting unintended newlines**.
- Adds `_preserve_chunk_boundary_whitespace()` to correctly restore leading/trailing whitespace from source chunks, mitigating model-side whitespace drift.

### 📝 List-Aware Chunk Splitting
- Updates `split_markdown_content()` to route results through `_align_chunk_boundaries_to_list_item_end()`.
- Introduces logic to:
  - Prefer boundaries at **list item ends**.
  - Fall back to list item starts when necessary.
  - Enforce token caps via nearest newline fallback.

### 📐 Token-Safe Boundary Adjustments
- New safety checks ensure all boundaries remain:
  - Strictly increasing,
  - Within the document range,
  - Within max token constraints when feasible.

### 🧪 Added Tests
Test suite now covers:
- Non-injected newline behavior during recombination.
- Chunk-edge whitespace preservation.
- Ensuring fenced code blocks remain within a single chunk.
- Proper boundary adjustments when splits fall inside list items.
- Token-cap safe behavior for oversized list items.

## Related Issue
<!-- No explicit issue referenced in the diff; add one here if applicable. -->

## Does this introduce a breaking change?
- [ ] Yes  
- [x] No  

## Type of change
- [x] Bugfix  
- [x] Feature (enhanced chunking logic)  
- [ ] Code style update  
- [ ] Refactoring  
- [ ] Documentation content changes  
- [ ] Other  

## Checklist
- [x] I have thoroughly tested my changes.  
- [x] All existing tests pass.  
- [x] I have added new tests where appropriate.  
- [x] I have followed the Co-op Translators coding conventions.  
- [x] I have documented changes where applicable.  

## Additional context
These changes significantly improve translation stability for Markdown files with complex list structures or code fences by ensuring chunk boundaries respect semantic Markdown structure while maintaining token safety.
