### PR TITLE
Core: Prevent list-item chunk splits around code placeholders

### DIFF
--- a/tests/co_op_translator/utils/llm/test_markdown_utils.py
+++ b/tests/co_op_translator/utils/llm/test_markdown_utils.py
@@ -175,6 +175,20 @@ def test_split_markdown_content():
     assert all(isinstance(chunk, str) for chunk in chunks)
 
 
+def test_split_markdown_content_keeps_list_item_with_code_placeholder():
+    """List item text and indented code placeholder should stay in the same chunk."""
+    content = """- Step 1: run this command\n    @@CODE_BLOCK_0@@\n\nParagraph after list item.\n"""
+
+    class MockTokenizer:
+        def encode(self, text):
+            return [0] * len(text)
+
+    chunks = split_markdown_content(content, 30, MockTokenizer())
+
+    assert len(chunks) >= 1
+    assert any("- Step 1" in chunk and "@@CODE_BLOCK_0@@" in chunk for chunk in chunks)
+
+
 @pytest.fixture
 def complex_dir_structure(tmp_path):
     """Create a more complex directory structure for testing nested paths."""


### PR DESCRIPTION
### Motivation
- Fix a bug where markdown chunking could split inside a list item which separated indented code placeholders (e.g. `@@CODE_BLOCK_x@@`) from their list lines and broke fence/indentation in translated output.
- Keep the change minimal and focused on chunking behavior to avoid wide-reaching changes to translation flow.
- Add a regression test to prevent future regressions for list items with code placeholders.

### Description
- Add `_group_lines_preserving_list_items` to `src/co_op_translator/utils/llm/markdown_utils.py` to group contiguous list-item lines so list blocks are treated as atomic units for splitting.
- Update `split_markdown_content` to use the new grouping function instead of naive `split("\n")` and adjust per-line token accounting so list-item blocks and indented placeholders remain together.
- Add a regression test `test_split_markdown_content_keeps_list_item_with_code_placeholder` to `tests/co_op_translator/utils/llm/test_markdown_utils.py` which asserts a list item and its `@@CODE_BLOCK_0@@` placeholder are present in the same chunk.

### Testing
- `python -m compileall src/co_op_translator/utils/llm/markdown_utils.py tests/co_op_translator/utils/llm/test_markdown_utils.py` completed successfully.
- `pytest -q tests/co_op_translator/utils/llm/test_markdown_utils.py -k 'split_markdown_content or process_markdown'` could not be run to completion in this environment due to `ModuleNotFoundError: No module named 'markdown_it'` during test collection.
- `poetry install --no-interaction` could not complete in this environment because dependency installation failed (unable to reach `pypi.org`), so full test validation requiring runtime dependencies was not possible.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69934425a6588321a4f53aff37948b8a)