### PR TITLE
Add language prompt and normalize Co-op Translator links in disclaimer

### DIFF
--- a/src/co_op_translator/core/llm/markdown_translator.py
+++ b/src/co_op_translator/core/llm/markdown_translator.py
@@ -9,6 +9,7 @@ from co_op_translator.utils.llm.markdown_utils import (
     process_markdown,
     update_links,
     generate_prompt_template,
+    _read_language_prompt_template,
     replace_code_blocks,
     restore_code_blocks,
     SPLIT_DELIMITER,
@@ -257,6 +258,9 @@ class MarkdownTranslator(ABC):
             "Preserve Markdown syntax and tokens exactly as written; "
             "if links are present, keep Markdown link structure [text](URL) and do not rewrite links as plain text."
         )
+        language_template = _read_language_prompt_template(output_lang)
+        if language_template:
+            system_text += f"\n\n{language_template}"
         user_text = template_text
         disclaimer_prompt = system_text + SPLIT_DELIMITER + user_text
 
@@ -270,7 +274,25 @@ class MarkdownTranslator(ABC):
             )
             return ""
 
-        return disclaimer
+        return self._normalize_disclaimer_links(disclaimer)
+
+    @staticmethod
+    def _normalize_disclaimer_links(disclaimer: str) -> str:
+        """Normalize known Co-op Translator links to Markdown format.
+
+        Some model outputs localize punctuation around the project name and URL,
+        for example: 「Co-op Translator」（https://github.com/Azure/co-op-translator）.
+        Convert these variants back to the expected Markdown link format.
+        """
+
+        if not disclaimer:
+            return disclaimer
+
+        pattern = re.compile(
+            r"(?:「|『|\")?Co-op Translator(?:」|』|\")?\s*[（(]\s*"
+            r"(https?://github\.com/Azure/co-op-translator)\s*[)）]"
+        )
+        return pattern.sub(r"[Co-op Translator](\1)", disclaimer)
 
     def _read_disclaimer_template_inner(self) -> str:
         """Read the packaged disclaimer template and return inner content between markers.

--- a/tests/co_op_translator/core/llm/test_markdown_translator.py
+++ b/tests/co_op_translator/core/llm/test_markdown_translator.py
@@ -85,6 +85,27 @@ async def test_generate_disclaimer_includes_markdown_safety_rules(real_markdown_
     assert len(captured_prompts) == 1
     assert "Preserve Markdown syntax and tokens exactly as written" in captured_prompts[0]
     assert "keep Markdown link structure [text](URL)" in captured_prompts[0]
+    assert "Japanese mode: preserve Markdown tokens strictly." in captured_prompts[0]
+    assert "NEVER rewrite links as plain text" in captured_prompts[0]
+
+
+@pytest.mark.asyncio
+async def test_generate_disclaimer_normalizes_japanese_style_link(real_markdown_translator):
+    """Disclaimer output should normalize Co-op Translator link to markdown syntax."""
+
+    with patch.object(
+        real_markdown_translator, "_run_prompt", new_callable=AsyncMock
+    ) as mock_run_prompt:
+        mock_run_prompt.return_value = (
+            "**免責事項**：\n"
+            "本書類はAI翻訳サービス「Co-op Translator」"
+            "（https://github.com/Azure/co-op-translator）を使用して翻訳されました。"
+        )
+
+        result = await real_markdown_translator.generate_disclaimer("ja")
+
+    assert "[Co-op Translator](https://github.com/Azure/co-op-translator)" in result
+    assert "「Co-op Translator」（https://github.com/Azure/co-op-translator）" not in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation

- Ensure disclaimer generation can include language-specific guidance and post-process model output to a consistent Markdown link format.

### Description

- Import `_read_language_prompt_template` and include a language-specific template into the system prompt in `generate_disclaimer` when available. 
- Add `_normalize_disclaimer_links` to convert localized/japanese-style project name + URL variants into the canonical Markdown link `[Co-op Translator](https://github.com/Azure/co-op-translator)` and call it before returning the disclaimer. 
- Add unit test expectations to assert the language prompt content is included in the generated system prompt and add a new test `test_generate_disclaimer_normalizes_japanese_style_link` to verify link normalization. 

### Testing

- Ran the translator unit tests in `tests/co_op_translator/core/llm/test_markdown_translator.py` with `pytest` and the suite covering the modified disclaimer logic passed. 
- The new test `test_generate_disclaimer_normalizes_japanese_style_link` passed and the existing disclaimer prompt test was updated and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7c7a72fcc832194378881fe26b658)