### PR TITLE
Include language-specific prompt templates in disclaimer generation and update tests

### DIFF
--- a/src/co_op_translator/core/llm/markdown_translator.py
+++ b/src/co_op_translator/core/llm/markdown_translator.py
@@ -9,6 +9,7 @@ from co_op_translator.utils.llm.markdown_utils import (
     process_markdown,
     update_links,
     generate_prompt_template,
+    _read_language_prompt_template,
     replace_code_blocks,
     restore_code_blocks,
     SPLIT_DELIMITER,
@@ -257,6 +258,9 @@ class MarkdownTranslator(ABC):
             "Preserve Markdown syntax and tokens exactly as written; "
             "if links are present, keep Markdown link structure [text](URL) and do not rewrite links as plain text."
         )
+        language_template = _read_language_prompt_template(output_lang)
+        if language_template:
+            system_text += f"\n\n{language_template}"
         user_text = template_text
         disclaimer_prompt = system_text + SPLIT_DELIMITER + user_text
 

--- a/tests/co_op_translator/core/llm/test_markdown_translator.py
+++ b/tests/co_op_translator/core/llm/test_markdown_translator.py
@@ -85,6 +85,8 @@ async def test_generate_disclaimer_includes_markdown_safety_rules(real_markdown_
     assert len(captured_prompts) == 1
     assert "Preserve Markdown syntax and tokens exactly as written" in captured_prompts[0]
     assert "keep Markdown link structure [text](URL)" in captured_prompts[0]
+    assert "Japanese mode: preserve Markdown tokens strictly." in captured_prompts[0]
+    assert "NEVER rewrite links as plain text" in captured_prompts[0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Ensure the disclaimer translation uses any packaged, language-specific prompt guidance so translations follow locale-specific rules.
- Update unit tests to reflect the additional language prompt content that should be included in the generated system prompt.

### Description
- Import `
_read_language_prompt_template` from `co_op_translator.utils.llm.markdown_utils` and call it in `MarkdownTranslator.generate_disclaimer` to fetch a language-specific prompt.
- If a language template is present, append it to the disclaimer `system_text` so provider prompts include locale-specific instructions while preserving existing Markdown preservation rules.
- Preserve existing behavior when no language template is found by falling back to the original system text.
- Update tests in `tests/co_op_translator/core/llm/test_markdown_translator.py` to assert the presence of the inserted language-specific guidance.

### Testing
- Ran `pytest tests/co_op_translator/core/llm/test_markdown_translator.py` and the modified tests passed.
- The `test_generate_disclaimer_includes_markdown_safety_rules` test verified the appended language template strings are included in the prompt and succeeded.
- The partial-mock translation workflow test `test_translate_markdown_partial_mock` was exercised and passed under the mocked `_run_prompt` implementation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7c7a72fcc832194378881fe26b658)