### PR TITLE
Core: Increase markdown chunk translation timeout

### DIFF
--- a/src/co_op_translator/core/llm/markdown_translator.py
+++ b/src/co_op_translator/core/llm/markdown_translator.py
@@ -36,7 +36,7 @@ class MarkdownTranslator(ABC):
     Provides common utilities and abstract methods to be implemented by providers.
     """
 
-    TRANSLATION_TIMEOUT_SECONDS = 300  # Translation timeout in seconds
+    TRANSLATION_TIMEOUT_SECONDS = 1000  # Translation timeout in seconds
 
     def __init__(
         self,


### PR DESCRIPTION
### Motivation
- Reduce spurious `Markdown translation timed out for chunk ...` errors by allowing longer per-chunk translation duration when large or slow responses occur.

### Description
- Increase `MarkdownTranslator.TRANSLATION_TIMEOUT_SECONDS` from `300` to `1000` in `src/co_op_translator/core/llm/markdown_translator.py` as a minimal change.

### Testing
- Ran `python -m compileall -q src/co_op_translator/core/llm/markdown_translator.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca0d962930832f9e2731524a590b04)